### PR TITLE
fix: update README to reflect Astro as the build tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Portfolio
 
-My portfolio build [Jekyll](https://jekyllrb.com/). See me in action at <https://rsseau.fr>.
+My portfolio built with [Astro](https://astro.build/). See me in action at <https://rsseau.fr>.
 
 ![screenshot](./public/screenshot.png)
 


### PR DESCRIPTION
## Summary
- Fix README to reflect the actual build tool (Astro) instead of Jekyll

## Verification
- Confirmed `package.json` uses Astro scripts and dependencies
